### PR TITLE
Correct generation of LLama3 prompt

### DIFF
--- a/src/meta.ts
+++ b/src/meta.ts
@@ -68,6 +68,10 @@ export class Llama2Chat extends BedrockFoundationModel {
   }
 }
 
+/**
+ * Generate LLama3 prompts according to https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3
+ */
+
 const BEGIN_OF_TEXT = "<|begin_of_text|>";
 const SYSTEM_HEADER = "<|start_header_id|>system<|end_header_id|>";
 const USER_HEADER = "<|start_header_id|>user<|end_header_id|>";
@@ -114,9 +118,9 @@ export class Llama3Chat extends BedrockFoundationModel {
   }
 
   override getChatPrompt(messages: ChatMessage[]): ChatMessage[] {
-    let llama2ChatPrompt = "";
+    let llama2ChatPrompt = `${BEGIN_OF_TEXT}`;
     if (messages[0]?.role === "system") {
-      llama2ChatPrompt += `${BEGIN_OF_TEXT}${SYSTEM_HEADER}\n\n${messages[0].message.trim()}${EOD}`;
+      llama2ChatPrompt += `${SYSTEM_HEADER}\n\n${messages[0].message.trim()}${EOD}`;
       messages = messages.slice(1);
     }
     if (messages.length % 2 != 1)
@@ -125,8 +129,8 @@ export class Llama3Chat extends BedrockFoundationModel {
       );
     messages.forEach((m, idx) => {
       idx % 2 === 0
-        ? (llama2ChatPrompt += `${USER_HEADER}\n\n${m.message.trim()}${EOD}${ASSISTANT_HEADER}`)
-        : (llama2ChatPrompt += `\n\n${m.message.trim()}${EOD}`);
+        ? (llama2ChatPrompt += `${USER_HEADER}\n\n${m.message.trim()}${EOD}\n${ASSISTANT_HEADER}`)
+        : (llama2ChatPrompt += `\n\n${m.message.trim()}${EOD}\n`);
     });
     return [{ role: "human", message: llama2ChatPrompt }];
   }

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -143,11 +143,11 @@ it("return body for LLama2", async () => {
       temperature: 1.0,
       topP: 1,
       stopSequences: [],
-    },
+    }
   );
   // Assert
   expect(body).toBe(
-    '{"prompt":"[INST] H [/INST]","max_gen_len":512,"temperature":1,"top_p":1}',
+    '{"prompt":"[INST] H [/INST]","max_gen_len":512,"temperature":1,"top_p":1}'
   );
 });
 
@@ -165,7 +165,7 @@ it("return body for Titan", async () => {
       temperature: 1.0,
       topP: 1,
       stopSequences: [],
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -199,7 +199,7 @@ it("return body for Titan - args override", async () => {
         stopSequences: ["A"],
         temperature: 0.1,
       },
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -227,7 +227,7 @@ it("return body for Claude 3", async () => {
       temperature: 1.0,
       topP: 1,
       stopSequences: [],
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -257,7 +257,7 @@ it("return body for Claude 3 - override args", async () => {
       temperature: 1.0,
       topP: 1,
       stopSequences: [],
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -292,7 +292,7 @@ it("return body for Claude 3 - override args", async () => {
         max_tokens: 200,
         system: "S1",
       },
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -323,7 +323,7 @@ it("return body for Claude < 3", async () => {
       temperature: 1.0,
       topP: 1,
       stopSequences: [],
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -356,7 +356,7 @@ it("return body for ai21", async () => {
       maxTokenCount: 50,
       stopSequences: ["A", "B"],
       modelArgs: { minTokens: 20 },
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -394,7 +394,7 @@ it("return body for ai21 - override common params", async () => {
           applyToNumber: true,
         },
       },
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -426,7 +426,7 @@ it("return body for cohere", async () => {
       temperature: 1.0,
       topP: 1,
       stopSequences: ["A", "B"],
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -458,7 +458,7 @@ it("return body for cohere - model args", async () => {
         max_tokens: 200,
         k: 4,
       },
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -491,7 +491,7 @@ it("return body for Mistral", async () => {
         max_tokens: 200,
         k: 4,
       },
-    },
+    }
   );
   // Assert
   expect(JSON.parse(body)).toStrictEqual({
@@ -537,7 +537,7 @@ it("return chat prompt for mistral - chat", async () => {
   });
 });
 
-it("return chat prompt for llama3 - chat", async () => {
+it("return chat prompt for llama3 - alternating S,H,A,H", async () => {
   const fm = fromModelId(Models.META_LLAMA3_8B_INSTRUCT_V1_0, {
     client: titanMockClient,
   });
@@ -553,13 +553,27 @@ it("return chat prompt for llama3 - chat", async () => {
     message:
       "<|begin_of_text|><|start_header_id|>system<|end_header_id|>" +
       "\n\nS<|eot_id|><|start_header_id|>user<|end_header_id|>" +
-      "\n\nH<|eot_id|><|start_header_id|>assistant<|end_header_id|>" +
-      "\n\nA<|eot_id|><|start_header_id|>user<|end_header_id|>" +
-      "\n\nH1<|eot_id|><|start_header_id|>assistant<|end_header_id|>",
+      "\n\nH<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>" +
+      "\n\nA<|eot_id|>\n<|start_header_id|>user<|end_header_id|>" +
+      "\n\nH1<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>",
   });
 });
 
-it("return chat prompt for llama3 - chat", async () => {
+it("return prompt for llama3 - only user message", async () => {
+  const fm = fromModelId(Models.META_LLAMA3_8B_INSTRUCT_V1_0, {
+    client: titanMockClient,
+  });
+  const msg = fm.getChatPrompt([{ role: "human", message: "H" }])[0];
+  // Assert
+  expect(msg).toStrictEqual({
+    role: "human",
+    message:
+      "<|begin_of_text|><|start_header_id|>user<|end_header_id|>" +
+      "\n\nH<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>",
+  });
+});
+
+it("throw exception for for llama3 - last message is ai", async () => {
   const fm = new Llama3Chat(Models.META_LLAMA3_8B_INSTRUCT_V1_0, {
     client: titanMockClient,
   });


### PR DESCRIPTION
LLama3 prompt was not correctly generated when only user message present. Also added `\n` after the `<|eot_id|>` tokens where necessary