### PR TITLE
Inference control via prompt

### DIFF
--- a/src/amazon_image.ts
+++ b/src/amazon_image.ts
@@ -312,7 +312,7 @@ export class NovaCanvas extends BedrockImageGenerationModel {
       };
     }
     const inferredBody = this.getBodyFromPrompt(
-      (promptInstructions ?? prompt).replace("\n", " "),
+      (promptInstructions ?? prompt).replaceAll("\n", " "),
       options.image?.split(",")?.at(1)
     );
 

--- a/src/bedrock_image_generation.ts
+++ b/src/bedrock_image_generation.ts
@@ -2,7 +2,6 @@ import {
   BedrockRuntimeClient,
   InvokeModelCommand,
 } from "@aws-sdk/client-bedrock-runtime";
-import fs from "fs";
 /**
  * Supported models
  */
@@ -101,7 +100,6 @@ export abstract class BedrockImageGenerationModel {
     options: ImageGenerationParams
   ): Promise<any> {
     const body = this.prepareBody(prompt, options);
-    fs.writeFileSync("dump.json", body);
     const command = new InvokeModelCommand({
       modelId: this.modelId,
       contentType: "application/json",

--- a/tests/infconfig.test.ts
+++ b/tests/infconfig.test.ts
@@ -1,0 +1,45 @@
+import { NovaCanvas } from "../src/amazon_image";
+import { ImageModels } from "../src/main";
+const m = new NovaCanvas(ImageModels.AMAZON_NOVA_CANVAS_V1_0);
+
+it("n", () => {
+  const res = m.getConfigFromString("n:4");
+  expect(res.numberOfImages).toBe(4);
+});
+
+it("size", () => {
+  const res = m.getConfigFromString("size:512x128");
+  expect(res.width).toBe(512);
+  expect(res.height).toBe(128);
+});
+
+it("scale", () => {
+  const res = m.getConfigFromString("scale:4");
+  expect(res.cfgScale).toBe(4);
+});
+
+it("seed", () => {
+  const res = m.getConfigFromString("seed:4");
+  expect(res.seed).toBe(4);
+});
+
+it("wrong key", () => {
+  expect(() => m.getConfigFromString("test:4")).toThrow();
+});
+
+describe("wrong value", () => {
+  ["n:a", "size:512", "size:654,76", "size:5xA"].forEach(() => {
+    expect(() => m.getConfigFromString("n:a")).toThrow();
+  });
+});
+
+it("complete", () => {
+  const res = m.getConfigFromString(" size:512x512, n:4, seed:12, scale:5");
+  expect(res).toStrictEqual({
+    width: 512,
+    height: 512,
+    seed: 12,
+    cfgScale: 5,
+    numberOfImages: 4,
+  });
+});

--- a/tests/nova-canvas-image.test.ts
+++ b/tests/nova-canvas-image.test.ts
@@ -100,9 +100,12 @@ it("remove", async () => {
 }, 30000);
 
 it("similar", async () => {
-  const resp = await fm.generateImage("different landscapes SIMILAR:0.5 N:3", {
-    image: getTestImage(),
-  });
+  const resp = await fm.generateImage(
+    "different landscapes SIMILAR:0.5|n:3, size:320x320, seed:5",
+    {
+      image: getTestImage(),
+    }
+  );
   expect(resp.length).toBe(3);
   expect(resp[0]?.includes("base64")).toBeTruthy();
 }, 30000);

--- a/tests/regex.test.ts
+++ b/tests/regex.test.ts
@@ -42,11 +42,6 @@ it("similar with integer", () => {
   expect(res.similarity).toBe("1");
 });
 
-it("n", () => {
-  const res = m.getPromptElements("N:3");
-  expect(res.numberOfImages).toBe("3");
-});
-
 it("outpaint", () => {
   const res = m.getPromptElements("OUTPAINT(DEFAULT)");
   expect(res.outpaint).toBe("DEFAULT");
@@ -68,14 +63,14 @@ describe("should not match", () => {
 
 it("support a complex prompt", () => {
   const res = m.getPromptElements(
-    "OUTPAINT N:2 SIMILAR:0.5 CONDITION(CANNY_EDGE:0.2) COLORS(#000000) NEGATIVE(dogs) REMOVE_BACKGROUND MASK(bird)"
+    "OUTPAINT SIMILAR:0.5 CONDITION(CANNY_EDGE:0.2) COLORS(#000000) NEGATIVE(dogs) REMOVE_BACKGROUND MASK(bird)"
   );
   expect(Object.values(res).filter((x) => x === undefined)).toStrictEqual([]);
 });
 
 it("retrieves the instructions a complex prompt", () => {
   const res = m.getPromptElements(
-    "  a nice view of the sea OUTPAINT N:2 SIMILAR:0.5 with a dog running CONDITION(CANNY_EDGE:0.2) COLORS(#000000) NEGATIVE(dogs) really cool REMOVE_BACKGROUND MASK(bird)"
+    "  a nice view of the sea OUTPAINT SIMILAR:0.5 with a dog running CONDITION(CANNY_EDGE:0.2) COLORS(#000000) NEGATIVE(dogs) really cool REMOVE_BACKGROUND MASK(bird)"
   );
   expect(res.instructions).toBe(
     "a nice view of the sea with a dog running really cool"


### PR DESCRIPTION
Add the possibility to control inference parameters via the prompt:

`| size:320x320, n:5, seed:8, scale:2`