### PR TITLE
Add configurable Stable Diffusion prompt

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -138,7 +138,7 @@ export function fromImageModelId(
 
 export function fromVideoModelId(
   modelId: ModelID,
-  params: VideoGenerationParams & NovaReelParams
+  params: BedrockFoundationModelParams & VideoGenerationParams & NovaReelParams
 ): BedrockVideoGenerationModel {
   switch (modelId.split("-")[0]) {
     case "amazon.nova":

--- a/tests/nova-canvas-image.test.ts
+++ b/tests/nova-canvas-image.test.ts
@@ -5,6 +5,13 @@ import fs from "fs";
 const fm = new NovaCanvas(ImageModels.AMAZON_NOVA_CANVAS_V1_0, {
   region: "us-east-1",
 });
+
+function getTestImage(): string {
+  const bytes = fs.readFileSync("tests/test-image.jpg");
+  const data = bytes.toString("base64");
+  return `data:image/jpeg;base64,${data}`;
+}
+
 //@ts-ignore
 const mockClient: BedrockRuntimeClient = {
   send: () => ({
@@ -46,12 +53,6 @@ it("validates body generation base", async () => {
   );
 });
 
-function getTestImage(): string {
-  const bytes = fs.readFileSync("tests/test-image.jpg");
-  const data = bytes.toString("base64");
-  return `data:image/jpeg;base64,${data}`;
-}
-
 it("image gen with conditioning text", async () => {
   const resp = await fm.generateImage(
     "a lanscape with mountains CONDITION(CANNY_EDGE:0.7)",
@@ -76,7 +77,7 @@ it("colors", async () => {
 }, 30000);
 
 it("validates the generation", async () => {
-  const resp = await fm.generateImage("a nice view", {
+  const resp = await fm.generateImage("a nice view | size:768x1024, seed:34", {
     size: {
       width: 512,
       height: 512,

--- a/tests/stablediffusion.test.ts
+++ b/tests/stablediffusion.test.ts
@@ -5,6 +5,13 @@ import {
   fromImageModelId,
   StableDiffusion3,
 } from "../src/main";
+import fs from "fs";
+
+function getTestImage(): string {
+  const bytes = fs.readFileSync("tests/test-image.jpg");
+  const data = bytes.toString("base64");
+  return `data:image/jpeg;base64,${data}`;
+}
 
 //@ts-ignore
 const mockClient: BedrockRuntimeClient = {
@@ -177,3 +184,25 @@ it("validates the generation - 3 large", async () => {
   });
   expect(resp[0]?.includes("base64")).toBeTruthy();
 }, 20000);
+
+describe("prompt", () => {
+  const fm = new StableDiffusion3(ImageModels.STABILITY_SD3_LARGE_V1_0, {
+    region: "us-west-2",
+  });
+
+  it("works", async () => {
+    const resp = await fm.generateImage(
+      "a nice view NEGATIVE(clouds) | aspect_ratio=2:3, seed=4",
+      {}
+    );
+    expect(resp[0]?.includes("base64")).toBeTruthy();
+  }, 20000);
+
+  it("image", async () => {
+    const resp = await fm.generateImage(
+      "a nice view NEGATIVE(clouds) | seed=4, strength=0.2",
+      { image: getTestImage() }
+    );
+    expect(resp[0]?.includes("base64")).toBeTruthy();
+  }, 20000);
+});


### PR DESCRIPTION
This PR add the possibility to configure inference parameters via the textual prompt.
It supports:
- NEGATIVE(<prompt>): negative prompt to be specified as part of the textual prompt
- aspect_ratio, seed, style_preset, cfg_scale, strength as inference parameters 

Example

```
hills and trees NEGATIVE(clouds) | seed=5, aspect_ratio=3:2
```